### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: docker/setup-qemu-action@v3
+
+    # Disabled since the ARM64 builds take a ridiculous amount of time.
+    # - uses: docker/setup-qemu-action@v3
 
     - uses: docker/setup-buildx-action@v3
 
@@ -52,7 +54,8 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         annotations: ${{ steps.meta.outputs.annotations }}
-        platforms: linux/amd64,linux/arm64
+        # Disabled since the ARM64 builds take a ridiculous amount of time.
+        # platforms: linux/amd64,linux/arm64
         # Build cache is scoped to branches by default.
         # We use the main branch as a fallback if there's no cache for the existing branch.
         # https://stackoverflow.com/a/77127188/5209106

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-FROM node:20.11 as builder
+FROM python:3.12-bookworm as builder
 
 # renovate: datasource=github-releases depName=bitwarden/sdk
 # TODO: pin to release tag when new release published on bitwarden/sdk; depends on aef6a21
 # ARG BWS_SDK_VERSION=0.4.0
 ARG BWS_SDK_BRANCH=main
-# renovate: datasource=github-releases depName=rust-lang/rust
-ARG RUST_VERSION=1.75.0
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
     PATH=/usr/local/cargo/bin:$PATH
 
-# Install Rust
+# Install Rust & Node
 RUN dpkgArch="$(dpkg --print-architecture)" &&\
     case "${dpkgArch##*-}" in \
         amd64) rustArch='x86_64-unknown-linux-gnu' ;; \
@@ -27,7 +25,10 @@ RUN dpkgArch="$(dpkg --print-architecture)" &&\
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME &&\
     rustup --version &&\
     cargo --version &&\
-    rustc --version
+    rustc --version &&\
+    apt update &&\
+    apt-get install -y --no-install-recommends npm &&\
+    rm -rf /var/lib/apt/lists/*
 
 # Clone BWS SDK
 RUN git clone https://github.com/bitwarden/sdk.git &&\
@@ -36,9 +37,6 @@ RUN git clone https://github.com/bitwarden/sdk.git &&\
 
 WORKDIR /sdk
 
-# Compile Rust package
-RUN cargo build --package bitwarden-py --release
-
 # Generate schemas
 RUN npm ci &&\
     npm run schemas
@@ -46,14 +44,9 @@ RUN npm ci &&\
 COPY build-reqs.txt .
 
 # Compile Python bindings
-RUN apt update &&\
-    apt install -y python3-pip &&\
-    rm /usr/lib/python3.*/EXTERNALLY-MANAGED || true &&\
-    pip install -r build-reqs.txt &&\
+RUN pip install --no-cache -r build-reqs.txt &&\
     cd languages/python &&\
-    python3 setup.py develop &&\
-    mv bitwarden_py.*.so bitwarden_py.so &&\
-    rm -rf /var/lib/apt/lists/*
+    maturin build --compatibility linux
 
 FROM python:3.12-slim-bookworm
 
@@ -66,14 +59,12 @@ ENV DEBUG=false
 WORKDIR /app
 
 COPY server/reqs.txt .
+COPY --from=builder /sdk/target/wheels/bitwarden_sdk*.whl .
 
-RUN pip install --no-cache-dir -r reqs.txt &&\
-    mkdir bitwarden_sdk
+RUN find . -name "bitwarden_sdk*.whl" -exec pip install --no-cache-dir -r reqs.txt {} \; &&\
+    rm -v bitwarden_sdk*.whl
 
 COPY server/ .
-
-COPY --from=builder /sdk/languages/python/bitwarden_py.so .
-COPY --from=builder /sdk/languages/python/bitwarden_sdk bitwarden_sdk
 
 EXPOSE 5000
 

--- a/build-reqs.txt
+++ b/build-reqs.txt
@@ -1,2 +1,1 @@
-setuptools
-setuptools-rust==1.8.1
+maturin[patchelf]==1.4.0

--- a/server/reqs.txt
+++ b/server/reqs.txt
@@ -1,3 +1,2 @@
 Flask==3.0.0
 Flask-RESTful==0.3.10
-python-dateutil==2.8.2


### PR DESCRIPTION
* [update Dockerfile, build deps for new build process](https://github.com/rippleFCL/bws-cache/commit/b4c2df1320cea859f6b9c8cafac41f0e0d508baa) (See bitwarden/sdk commit 9cad470). This involved swapping out the base image for the build stage to ensure the wheel built by maturin was compatible with the base image of the final stage.
* [disable ARM64 builds for the time being](https://github.com/rippleFCL/bws-cache/commit/9f89a879b4fac00141be1dc498764a00999f970f) - Compiling Rust on ARM through QEMU causes builds to take in excess of 2 hours.