### PR TITLE
feat: `/stats` endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This allows lookup by either ID or key, as shown below.
 * `/key/<string:secret_key>` - Secret key lookup
 * `/reset` - Clear secret and keymap cache
 * `/metrics` - Prometheus metrics
+* `/stats` - bws-cache statistics
 
 ## Authentication
 

--- a/server/client.py
+++ b/server/client.py
@@ -11,7 +11,7 @@ from threading import Lock, Thread
 
 import yaml
 from bitwarden_sdk import BitwardenClient, DeviceType, client_settings_from_dict
-from models import ResetStats
+from models import CacheStats
 from prom_client import PromMetricsClient
 
 PARSE_SECRET_VALUES = os.environ.get("PARSE_SECRET_VALUES", "false").lower() == "true"
@@ -311,14 +311,16 @@ class CachedBWSClient:
                 self.secret_cache[secret.id] = secret
                 self.key_map[secret.key] = secret.id
 
-    def reset_cache(self) -> ResetStats:
+    def reset_cache(self) -> CacheStats:
         logger.debug("resetting cache")
         with self.cache_lock:
             secret_cache_len = len(self.secret_cache)
             key_map_len = len(self.key_map)
             self.secret_cache = {}
             self.key_map = {}
-        return ResetStats(secret_cache_len, key_map_len)
+        return CacheStats(
+            secret_cache_size=secret_cache_len, keymap_cache_size=key_map_len
+        )
 
 
 class ClientList:

--- a/server/client.py
+++ b/server/client.py
@@ -286,11 +286,12 @@ class CachedBWSClient:
         return cached_secret
 
     def _load_secret_keys(self):
-        logger.debug("loading secret key map")
-        secret_keys = self.client.list_secrets()
+        logger.debug("generating secret key map")
+        secrets = self.client.list_secrets()
         with self.cache_lock:
-            for secret in secret_keys:
+            for secret in secrets:
                 self.key_map[secret.key] = secret.id
+            logger.debug(f"generated secret key map with {len(self.key_map)} keys")
 
     def get_secret_by_key(self, secret_key: str):
         if not self.key_map:

--- a/server/client.py
+++ b/server/client.py
@@ -446,4 +446,8 @@ class BwsClientManager:
             keymap_cache_size=keymap_cache_size_sum,
         )
 
-        return StatsResponse(num_clients=len(clients_stats), client_stats=clients_stats, total_stats=total_stats)
+        return StatsResponse(
+            num_clients=len(clients_stats),
+            client_stats=clients_stats,
+            total_stats=total_stats,
+        )

--- a/server/client.py
+++ b/server/client.py
@@ -118,7 +118,9 @@ class BWSClient:
     def auth(self, cache: bool = True):
         try:
             logger.debug("authenticating client")
-            auth_cache_file = f"/tmp/token_{generate_hash(self.bws_token)}" if cache else ""
+            auth_cache_file = (
+                f"/dev/shm/token_{generate_hash(self.bws_token)}" if cache else ""
+            )
             # fixme: when rapid requests made with valid but expired token, the folllwing line hangs indefinitely
             # not fixed but restructured to call this less
             self.bws_client.auth().login_access_token(self.bws_token, auth_cache_file)

--- a/server/models.py
+++ b/server/models.py
@@ -24,3 +24,9 @@ class ResetResponse(SuccResonse):
 
 class ErrorResponse(BaseModel):
     detail: str
+
+
+class StatsResponse(BaseModel):
+    num_clients: int
+    client_stats: dict[str, CacheStats]
+    total_stats: CacheStats

--- a/server/models.py
+++ b/server/models.py
@@ -12,14 +12,14 @@ class SuccResonse(BaseModel):
     status: Literal["success"]
 
 
-class ResetStats(BaseModel):
+class CacheStats(BaseModel):
     keymap_cache_size: int
     secret_cache_size: int
 
 
 class ResetResponse(SuccResonse):
-    before: ResetStats
-    after: ResetStats
+    before: CacheStats
+    after: CacheStats
 
 
 class ErrorResponse(BaseModel):

--- a/server/server.py
+++ b/server/server.py
@@ -18,7 +18,7 @@ from fastapi.responses import PlainTextResponse
 from models import (
     ErrorResponse,
     ResetResponse,
-    ResetStats,
+    CacheStats,
     SecretResponse,
 )
 from prom_client import PromMetricsClient
@@ -152,7 +152,7 @@ def reset_cache(authorization: Annotated[str, Depends(handle_auth)]):
     return ResetResponse(
         "success",
         before=stats,
-        after=ResetStats(secret_cache_size=0, keymap_cache_size=0),
+        after=CacheStats(secret_cache_size=0, keymap_cache_size=0),
     )
 
 

--- a/server/server.py
+++ b/server/server.py
@@ -20,6 +20,7 @@ from models import (
     ResetResponse,
     CacheStats,
     SecretResponse,
+    StatsResponse,
 )
 from prom_client import PromMetricsClient
 
@@ -216,3 +217,19 @@ def prometheus_metrics(accept: Annotated[str | str, Header()] = ""):
     generated_data, content_type = prom_client.generate_metrics(accept)
     headers = {"Content-Type": content_type}
     return PlainTextResponse(generated_data, headers=headers)
+
+
+@api.get(
+    "/stats",
+    response_model=StatsResponse,
+    responses={
+        200: {
+            "model": StatsResponse,
+            "description": "Successful response with stats data",
+        },
+        500: {"model": ErrorResponse, "description": "Internal server error"},
+    },
+)
+@handle_api_errors
+def get_stats():
+    return client_manager.stats()

--- a/server/server.py
+++ b/server/server.py
@@ -192,7 +192,6 @@ def get_key(
     authorization: Annotated[str, Depends(handle_auth)],
     secret_key: str,
 ):
-    print(authorization)
     client = client_manager.get_client_by_token(authorization)
     return client.get_secret_by_key(secret_key).to_json()
 

--- a/server/server.py
+++ b/server/server.py
@@ -151,7 +151,7 @@ def reset_cache(authorization: Annotated[str, Depends(handle_auth)]):
     client = client_manager.get_client_by_token(authorization)
     stats = client.reset_cache()
     return ResetResponse(
-        "success",
+        status="success",
         before=stats,
         after=CacheStats(secret_cache_size=0, keymap_cache_size=0),
     )

--- a/server/server.py
+++ b/server/server.py
@@ -98,7 +98,7 @@ def custom_openapi():
         return api.openapi_schema
     openapi_schema = get_openapi(
         title="bws-cache",
-        version="1.0.0",
+        version="1.1.0",
         summary="bws-cache OpenAPI Schema",
         description='<a href="https://github.com/rippleFCL/bws-cache">Github</a> | <a href="https://github.com/rippleFCL/bws-cache/issues">Issues</a>',
         routes=api.routes,


### PR DESCRIPTION
This is supplementary to the `/metrics` endpoint, and arguably sort of pointless considering that exists, but I started building it for debugging and then realised it was kinda cool, so I built it out a little to make it more "production-ready".