### PR TITLE
chore(pyproject): fix poetry 2.0 compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,10 @@ FROM python:3.12-slim-bookworm AS requirement-builder
 
 WORKDIR /app
 
-RUN pip install --no-cache-dir poetry
+RUN pip install --no-cache-dir poetry poetry-plugin-export
 
 COPY ./pyproject.toml /app
 COPY ./poetry.lock /app
-
 
 RUN poetry export --without-hashes -f requirements.txt --output requirements.txt
 


### PR DESCRIPTION
See poetry 2.0.0 release notes https://github.com/python-poetry/poetry/releases/tag/2.0.0:

> Remove the dependency on `poetry-plugin-export` so that `poetry export` is not included per default