### PR TITLE
ci(build): grant content write permission to release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,8 @@ jobs:
   release:
     if: github.event_name == 'push'
     needs: build
+    permissions:
+      contents: write
     uses: ./.github/workflows/release.yml
     secrets: inherit
     with:


### PR DESCRIPTION
Prior to this change, the relase workflow failed due to missing permissions

This change adds the necessary permisions