### PR TITLE
fix(ansible): increase request timeout

### DIFF
--- a/ansible_collection/CHANGELOG.md
+++ b/ansible_collection/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+
+fix: increase request timeout to 15 seconds
+
 ## 1.2.0
 
 * feat: feat(secret.py): added headers to ansible lookup plugin

--- a/ansible_collection/galaxy.yml
+++ b/ansible_collection/galaxy.yml
@@ -9,7 +9,7 @@ namespace: ripplefcl
 name: bwscache
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.0
+version: 1.2.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/ansible_collection/plugins/lookup/secret.py
+++ b/ansible_collection/plugins/lookup/secret.py
@@ -62,6 +62,8 @@ from ansible.utils.display import Display  # type: ignore # noqa: E402
 
 display = Display()
 
+REQUEST_TIMEOUT = 15
+
 
 class BwsCacheSecretLookupException(AnsibleLookupError):
     pass
@@ -105,9 +107,9 @@ class BwsCacheSecretLookup:
 
         parsed_url = urlparse(self.bws_cache_url)
         conn = (
-            http.client.HTTPSConnection(parsed_url.netloc, timeout=5)
+            http.client.HTTPSConnection(parsed_url.netloc, timeout=REQUEST_TIMEOUT)
             if parsed_url.scheme == "https"
-            else http.client.HTTPConnection(parsed_url.netloc, timeout=5)
+            else http.client.HTTPConnection(parsed_url.netloc, timeout=REQUEST_TIMEOUT)
         )
 
         # Ensure endpoint starts with a slash


### PR DESCRIPTION
BWS refreshes can take a long time (~10s). If a request is made during an update, or a request triggers an update, the request would time out. This change increases the Ansible lookup module's timeout to 15 seconds to account for the default `REFRESH_RATE` with some additional buffer.